### PR TITLE
assumeRole implementation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.5" % "test, it",
   "com.auth0" % "java-jwt" % "3.8.0",
   "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % Test,
-  "com.typesafe.akka" %% "akka-stream-testkit" % "2.5.19" % Test,
+  "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % Test,
   "com.amazonaws" % "aws-java-sdk-sts" % "1.11.467" % IntegrationTest)
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2"
 services:
 
   keycloak:
-    image: wbaa/rokku-dev-keycloak:0.0.5
+    image: wbaa/rokku-dev-keycloak:0.0.6
     environment:
       - KEYCLOAK_USER=admin
       - KEYCLOAK_PASSWORD=admin
@@ -10,7 +10,7 @@ services:
       - 8080:8080
 
   mariadb:
-    image: wbaa/rokku-dev-mariadb:0.0.5
+    image: wbaa/rokku-dev-mariadb:0.0.8
     environment:
       - MYSQL_ROOT_PASSWORD=admin
     ports:

--- a/scripts/rokku-assume-role.sh
+++ b/scripts/rokku-assume-role.sh
@@ -1,0 +1,13 @@
+token_session=$(curl -s -X POST http://localhost:8080/auth/realms/auth-rokku/protocol/openid-connect/token  -H "Content-Type: application/x-www-form-urlencoded" -d "username=userone" -d "password=password" -d 'grant_type=password' -d 'client_id=sts-rokku' | jq -r '.access_token')
+echo "Read keycloak token: $token_session"
+if [ ${#token_session} -gt 10 ]
+then
+  awsjson=$(aws sts assume-role --endpoint-url http://localhost:12345 --role-session-name test --role-arn arn:aws:iam::account-id:role/admin  --duration-seconds 72000  --token-code "$token_session")
+  echo "Aws Json recieved: $awsjson"
+  export AWS_ACCESS_KEY_ID=$(echo $awsjson | jq -r '.Credentials.AccessKeyId')
+  export AWS_SECRET_ACCESS_KEY=$(echo $awsjson | jq -r '.Credentials.SecretAccessKey')
+  export AWS_SESSION_TOKEN=$(echo $awsjson | jq -r '.Credentials.SessionToken')
+else
+ echo "Invalid user credentials"
+fi
+

--- a/scripts/rokku-get-session-token.sh
+++ b/scripts/rokku-get-session-token.sh
@@ -1,0 +1,13 @@
+token_session=$(curl -s -X POST http://localhost:8080/auth/realms/auth-rokku/protocol/openid-connect/token  -H "Content-Type: application/x-www-form-urlencoded" -d "username=testuser" -d "password=password" -d 'grant_type=password' -d 'client_id=sts-rokku' | jq -r '.access_token')
+echo "Read keycloak token: $token_session"
+if [ ${#token_session} -gt 10 ]
+then
+  awsjson=$(aws sts get-session-token --endpoint-url http://localhost:12345 --duration-seconds 72000  --token-code "$token_session")
+  echo "Aws Json recieved: $awsjson"
+  export AWS_ACCESS_KEY_ID=$(echo $awsjson | jq -r '.Credentials.AccessKeyId')
+  export AWS_SECRET_ACCESS_KEY=$(echo $awsjson | jq -r '.Credentials.SecretAccessKey')
+  export AWS_SESSION_TOKEN=$(echo $awsjson | jq -r '.Credentials.SessionToken')
+else
+ echo "Invalid user credentials"
+fi
+

--- a/src/main/scala/com/ing/wbaa/rokku/sts/api/xml/TokenXML.scala
+++ b/src/main/scala/com/ing/wbaa/rokku/sts/api/xml/TokenXML.scala
@@ -3,7 +3,8 @@ package com.ing.wbaa.rokku.sts.api.xml
 import java.util.UUID
 
 import akka.http.scaladsl.marshallers.xml.ScalaXmlSupport
-import com.ing.wbaa.rokku.sts.data.aws.AwsCredentialWithToken
+import com.ing.wbaa.rokku.sts.data.AuthenticationTokenId
+import com.ing.wbaa.rokku.sts.data.aws.{ AwsCredentialWithToken, AwsRoleArn }
 
 import scala.xml.NodeSeq
 
@@ -20,6 +21,32 @@ trait TokenXML extends ScalaXmlSupport {
     </GetSessionTokenResponse>
   }
 
+  protected def assumeRoleResponseToXML(
+      awsCredentialWithToken: AwsCredentialWithToken,
+      roleArn: AwsRoleArn,
+      roleSessionName: String,
+      keycloakTokenId: AuthenticationTokenId
+  ): NodeSeq = {
+    <AssumeRoleResponse>
+      <AssumeRoleResult>
+        { assumedRoleUserToXml(roleArn, roleSessionName) }
+        { credentialToXml(awsCredentialWithToken) }
+        <Provider>{ providerID }</Provider>
+      </AssumeRoleResult>
+      <ResponseMetadata>
+        <RequestId>{ requestId }</RequestId>
+      </ResponseMetadata>
+    </AssumeRoleResponse>
+  }
+
+  /**
+   * aws doc:
+   * The issuing authority of the web identity token presented. For OpenID Connect ID tokens,
+   * this contains the value of the iss field. For OAuth 2.0 access tokens,
+   * this contains the value of the ProviderId parameter that was passed in the AssumeRoleWithWebIdentity request.
+   */
+  private val providerID = "keycloak.wbaa.ing"
+
   private def credentialToXml(awsCredentialWithToken: AwsCredentialWithToken): NodeSeq = {
     <Credentials>
       <SessionToken>{ awsCredentialWithToken.session.sessionToken.value }</SessionToken>
@@ -27,5 +54,24 @@ trait TokenXML extends ScalaXmlSupport {
       <Expiration>{ awsCredentialWithToken.session.expiration.value }</Expiration>
       <AccessKeyId>{ awsCredentialWithToken.awsCredential.accessKey.value }</AccessKeyId>
     </Credentials>
+  }
+
+  /**
+   * aws doc:
+   * The Amazon Resource Name (ARN) and the assumed role ID,
+   * which are identifiers that you can use to refer to the resulting temporary security credentials.
+   * For example, you can reference these credentials as a principal in a resource-based policy
+   * by using the ARN or assumed role ID.
+   * The ARN and ID include the RoleSessionName that you specified when you called AssumeRole
+   *
+   * @param roleArn         - arn role e.g. arn:rokku:sts...
+   * @param roleSessionName - the session name
+   * @return
+   */
+  private def assumedRoleUserToXml(roleArn: AwsRoleArn, roleSessionName: String): NodeSeq = {
+    <AssumedRoleUser>
+      <Arn>{ s"${roleArn.arn}/$roleSessionName" }</Arn>
+      <AssumedRoleId>{ s"id:$roleSessionName" }</AssumedRoleId>
+    </AssumedRoleUser>
   }
 }

--- a/src/main/scala/com/ing/wbaa/rokku/sts/data/AuthenticationUserInfo.scala
+++ b/src/main/scala/com/ing/wbaa/rokku/sts/data/AuthenticationUserInfo.scala
@@ -7,4 +7,5 @@ case class UserGroup(value: String) extends AnyVal
 case class AuthenticationUserInfo(
     userName: UserName,
     userGroups: Set[UserGroup],
-    keycloakTokenId: AuthenticationTokenId)
+    keycloakTokenId: AuthenticationTokenId,
+    userRoles: Set[UserAssumeRole])

--- a/src/main/scala/com/ing/wbaa/rokku/sts/data/STSUserInfo.scala
+++ b/src/main/scala/com/ing/wbaa/rokku/sts/data/STSUserInfo.scala
@@ -4,8 +4,16 @@ import com.ing.wbaa.rokku.sts.data.aws.{ AwsAccessKey, AwsSecretKey }
 
 case class UserName(value: String) extends AnyVal
 
+case class UserAssumeRole(value: String) extends AnyVal
+
 case class STSUserInfo(
     userName: UserName,
     userGroup: Set[UserGroup],
     awsAccessKey: AwsAccessKey,
-    awsSecretKey: AwsSecretKey)
+    awsSecretKey: AwsSecretKey,
+    userRole: Option[UserAssumeRole])
+
+sealed trait TokenStatus
+case object TokenActive extends TokenStatus
+case class TokenActiveForRole(role: UserAssumeRole) extends TokenStatus
+case object TokenNotActive extends TokenStatus

--- a/src/main/scala/com/ing/wbaa/rokku/sts/data/aws/AwsRoleArn.scala
+++ b/src/main/scala/com/ing/wbaa/rokku/sts/data/aws/AwsRoleArn.scala
@@ -1,0 +1,30 @@
+package com.ing.wbaa.rokku.sts.data.aws
+
+import com.ing.wbaa.rokku.sts.data.{ AuthenticationUserInfo, UserAssumeRole }
+import com.typesafe.scalalogging.LazyLogging
+
+case class AwsRoleArn(arn: String) extends LazyLogging {
+
+  /**
+   * Checks whether or not this ARN is contained in a set of roles that the user has.
+   *
+   * @param userInfo The user from keycloak that would like to assume the role this ARN specifies
+   * @return The role the user can assume with this ARN
+   */
+  def getRoleUserCanAssume(userInfo: AuthenticationUserInfo): Option[UserAssumeRole] = {
+    logger.debug("arn = {}", arn)
+    logger.debug("user roles = {}", userInfo.userRoles)
+    getRoleFromArn.filter(extractedRole => userInfo.userRoles.map(_.value).contains(extractedRole.value))
+  }
+
+  /**
+   * get the role-name from ARN string
+   *
+   * Arn format:
+   * "arn:aws:iam::account-id:role/role-name"
+   */
+  private[this] val getRoleFromArn: Option[UserAssumeRole] = {
+    val arnRegex = "arn:aws:iam::.+:role/(.+)".r
+    arnRegex.findFirstMatchIn(arn).filter(_.groupCount == 1).map(theMatch => UserAssumeRole(theMatch.group(1)))
+  }
+}

--- a/src/main/scala/com/ing/wbaa/rokku/sts/keycloak/KeycloakTokenVerifier.scala
+++ b/src/main/scala/com/ing/wbaa/rokku/sts/keycloak/KeycloakTokenVerifier.scala
@@ -38,7 +38,8 @@ trait KeycloakTokenVerifier extends LazyLogging {
           keycloakToken.getOtherClaims
             .getOrDefault("user-groups", new util.ArrayList[String]())
             .asInstanceOf[util.ArrayList[String]].asScala.toSet.map(UserGroup),
-          AuthenticationTokenId(keycloakToken.getId)
+          AuthenticationTokenId(keycloakToken.getId),
+          keycloakToken.getRealmAccess.getRoles.asScala.toSet.map(UserAssumeRole)
         ))
     case Failure(exc: VerificationException) =>
       logger.warn("Token (value={}) verification failed ex={}", token.value, exc.getMessage)

--- a/src/test/scala/com/ing/wbaa/rokku/sts/api/AdminApiTest.scala
+++ b/src/test/scala/com/ing/wbaa/rokku/sts/api/AdminApiTest.scala
@@ -26,8 +26,8 @@ class AdminApiTest extends WordSpec
 
     protected[this] def verifyAuthenticationToken(token: BearerToken): Option[AuthenticationUserInfo] =
       token.value match {
-        case "valid"    => Some(AuthenticationUserInfo(UserName("username"), Set(UserGroup("admins"), UserGroup("group2")), AuthenticationTokenId("tokenOk")))
-        case "notAdmin" => Some(AuthenticationUserInfo(UserName("username"), Set(UserGroup("group1"), UserGroup("group2")), AuthenticationTokenId("tokenOk")))
+        case "valid"    => Some(AuthenticationUserInfo(UserName("username"), Set(UserGroup("admins"), UserGroup("group2")), AuthenticationTokenId("tokenOk"), Set.empty))
+        case "notAdmin" => Some(AuthenticationUserInfo(UserName("username"), Set(UserGroup("group1"), UserGroup("group2")), AuthenticationTokenId("tokenOk"), Set.empty))
         case _          => None
       }
 

--- a/src/test/scala/com/ing/wbaa/rokku/sts/api/STSApiTest.scala
+++ b/src/test/scala/com/ing/wbaa/rokku/sts/api/STSApiTest.scala
@@ -4,7 +4,7 @@ import java.time.Instant
 
 import akka.http.scaladsl.model.headers.Cookie
 import akka.http.scaladsl.model.{ FormData, StatusCodes }
-import akka.http.scaladsl.server.{ AuthorizationFailedRejection, MissingQueryParamRejection, Route }
+import akka.http.scaladsl.server.{ AuthorizationFailedRejection, MissingFormFieldRejection, MissingQueryParamRejection, Route }
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.ing.wbaa.rokku.sts.data
 import com.ing.wbaa.rokku.sts.data._
@@ -22,13 +22,33 @@ class STSApiTest extends WordSpec with DiagrammedAssertions with ScalatestRouteT
     override protected[this] def getSessionTokenResponseToXML(awsCredentialWithToken: AwsCredentialWithToken): NodeSeq =
       <getSessionToken></getSessionToken>
 
+    override protected[this] def assumeRoleResponseToXML(
+        awsCredentialWithToken: AwsCredentialWithToken,
+        roleArn: AwsRoleArn,
+        roleSessionName: String,
+        keycloakTokenId: AuthenticationTokenId
+    ): NodeSeq = <assumeRole></assumeRole>
+
     override def verifyAuthenticationToken(token: BearerToken): Option[AuthenticationUserInfo] =
       token.value match {
-        case "valid" => Some(data.AuthenticationUserInfo(UserName("name"), Set(UserGroup("testgroup")), AuthenticationTokenId("token")))
+        case "valid" => Some(data.AuthenticationUserInfo(UserName("name"), Set(UserGroup("testgroup")), AuthenticationTokenId("token"), Set(UserAssumeRole("testrole"))))
         case _       => None
       }
 
     override protected[this] def getAwsCredentialWithToken(userName: UserName, groups: Set[UserGroup], duration: Option[Duration]): Future[AwsCredentialWithToken] = {
+      Future.successful(AwsCredentialWithToken(
+        AwsCredential(
+          AwsAccessKey("accesskey"),
+          AwsSecretKey("secretkey")
+        ),
+        AwsSession(
+          AwsSessionToken("token"),
+          AwsSessionTokenExpiration(Instant.ofEpochMilli(duration.getOrElse(1.second).toMillis))
+        )
+      ))
+    }
+
+    override protected[this] def getAwsCredentialWithToken(userName: UserName, userGroups: Set[UserGroup], role: UserAssumeRole, duration: Option[Duration]): Future[AwsCredentialWithToken] = {
       Future.successful(AwsCredentialWithToken(
         AwsCredential(
           AwsAccessKey("accesskey"),
@@ -46,6 +66,12 @@ class STSApiTest extends WordSpec with DiagrammedAssertions with ScalatestRouteT
   private val s3RoutesWithExpirationTime: Route = new MockStsApi() {
     override protected[this] def getSessionTokenResponseToXML(awsCredentialWithToken: AwsCredentialWithToken): NodeSeq =
       <getSessionToken><Expiration>{ awsCredentialWithToken.session.expiration.value }</Expiration></getSessionToken>
+    override protected[this] def assumeRoleResponseToXML(
+        awsCredentialWithToken: AwsCredentialWithToken,
+        roleArn: AwsRoleArn,
+        roleSessionName: String,
+        keycloakTokenId: AuthenticationTokenId
+    ): NodeSeq = <assumeRole><Expiration>{ awsCredentialWithToken.session.expiration.value }</Expiration></assumeRole>
   }.stsRoutes
 
   val validOAuth2TokenHeader: RequestTransformer = addHeader("Authorization", "Bearer valid")
@@ -54,14 +80,15 @@ class STSApiTest extends WordSpec with DiagrammedAssertions with ScalatestRouteT
   val invalidOAuth2TokenCookie: RequestTransformer = addHeader(Cookie("X-Authorization-Token", "invalid"))
 
   val actionGetSessionToken = "?Action=GetSessionToken"
+  val actionAssumeRole = "?Action=AssumeRole"
   val durationQuery = "&DurationSeconds=3600"
   val roleNameSessionQuery = "&RoleSessionName=app1"
-  val arnQuery = "&RoleArn=arn:aws:iam::123456789012:role/testgroup"
+  val arnQuery = "&RoleArn=arn:aws:iam::123456789012:role/testrole"
   val webIdentityTokenQuery = "&WebIdentityToken=Atza%7CIQ"
   val providerIdQuery = "&ProviderId=testProvider.com"
   val tokenCodeQuery = "&TokenCode=sdfdsfgg"
 
-  "STS api the GET method" should {
+  "STS api the GET method for GetSessionToken" should {
 
     "return rejection because missing the Action parameter" in {
       Get(s"/") ~> s3Routes ~> check {
@@ -110,7 +137,7 @@ class STSApiTest extends WordSpec with DiagrammedAssertions with ScalatestRouteT
       }.toMap
   }
 
-  "STS api the POST method" should {
+  "STS api the POST method for GetSessionToken" should {
     "return rejection because missing the Action parameter" in {
       Post("/") ~> s3Routes ~> check {
         assert(rejections.contains(MissingQueryParamRejection("Action")))
@@ -127,6 +154,88 @@ class STSApiTest extends WordSpec with DiagrammedAssertions with ScalatestRouteT
       Post("/", FormData(queryToFormData(actionGetSessionToken, durationQuery))) ~> validOAuth2TokenHeader ~> s3RoutesWithExpirationTime ~> check {
         assert(status == StatusCodes.OK)
         assert(responseAs[String] == "<getSessionToken><Expiration>1970-01-01T01:00:00Z</Expiration></getSessionToken>")
+      }
+    }
+  }
+
+  "STS api the GET method for assumeRole" should {
+
+    "return a session token because credentials are valid" in {
+      Get(s"/$actionAssumeRole$arnQuery$roleNameSessionQuery") ~> validOAuth2TokenHeader ~> s3Routes ~> check {
+        assert(status == StatusCodes.OK)
+        assert(responseAs[String] == "<assumeRole></assumeRole>")
+      }
+    }
+
+    "return a session token with 1h expiration time because credentials are valid" in {
+      Get(s"/$actionAssumeRole$durationQuery$arnQuery$roleNameSessionQuery") ~> validOAuth2TokenHeader ~> s3RoutesWithExpirationTime ~> check {
+        assert(status == StatusCodes.OK)
+        assert(responseAs[String] == "<assumeRole><Expiration>1970-01-01T01:00:00Z</Expiration></assumeRole>")
+      }
+    }
+
+    "return rejection because invalid credentials" in {
+      Get(s"/$actionAssumeRole$arnQuery$roleNameSessionQuery") ~> invalidOAuth2TokenHeader ~> s3Routes ~> check {
+        assert(rejections.contains(AuthorizationFailedRejection))
+      }
+    }
+
+    "return rejection because no arn parameter" in {
+      Get(s"/$actionAssumeRole$roleNameSessionQuery") ~> invalidOAuth2TokenHeader ~> s3Routes ~> check {
+        assert(rejections.contains(MissingQueryParamRejection("RoleArn")))
+      }
+    }
+
+    "return rejection because no roleSessionName parameter" in {
+      Get(s"/$actionAssumeRole$arnQuery") ~> invalidOAuth2TokenHeader ~> s3Routes ~> check {
+        assert(rejections.contains(MissingQueryParamRejection("RoleSessionName")))
+      }
+    }
+
+    "return rejection because no credentials" in {
+      Get(s"/$actionAssumeRole$arnQuery$roleNameSessionQuery") ~> s3Routes ~> check {
+        assert(rejections.contains(AuthorizationFailedRejection))
+      }
+    }
+  }
+
+  "STS api the POST method for assumeRole" should {
+
+    "return a session token because credentials are valid" in {
+      Post("/", FormData(queryToFormData(actionAssumeRole, arnQuery, roleNameSessionQuery, durationQuery))) ~> validOAuth2TokenHeader ~> s3Routes ~> check {
+        assert(status == StatusCodes.OK)
+        assert(responseAs[String] == "<assumeRole></assumeRole>")
+      }
+    }
+
+    "return rejection because invalid credentials" in {
+      Post("/", FormData(queryToFormData(actionAssumeRole, arnQuery, roleNameSessionQuery, durationQuery))) ~> invalidOAuth2TokenHeader ~> s3Routes ~> check {
+        assert(rejections.contains(AuthorizationFailedRejection))
+      }
+    }
+
+    "return rejection because no arn parameter" in {
+      Post("/", FormData(queryToFormData(actionAssumeRole, roleNameSessionQuery, durationQuery))) ~> invalidOAuth2TokenHeader ~> s3Routes ~> check {
+        assert(rejections.contains(MissingFormFieldRejection("RoleArn")))
+      }
+    }
+
+    "return rejection because no roleSessionName parameter" in {
+      Post("/", FormData(queryToFormData(actionAssumeRole, arnQuery))) ~> invalidOAuth2TokenHeader ~> s3Routes ~> check {
+        assert(rejections.contains(MissingFormFieldRejection("RoleSessionName")))
+      }
+    }
+
+    "return rejection because no credentials" in {
+      Post("/", FormData(queryToFormData(actionAssumeRole, arnQuery, roleNameSessionQuery, durationQuery))) ~> s3Routes ~> check {
+        assert(rejections.contains(AuthorizationFailedRejection))
+      }
+    }
+
+    "return a session token with 1h expiration time because valid credentials" in {
+      Post("/", FormData(queryToFormData(actionAssumeRole, arnQuery, roleNameSessionQuery, durationQuery))) ~> validOAuth2TokenHeader ~> s3RoutesWithExpirationTime ~> check {
+        assert(status == StatusCodes.OK)
+        assert(responseAs[String] == "<assumeRole><Expiration>1970-01-01T01:00:00Z</Expiration></assumeRole>")
       }
     }
   }

--- a/src/test/scala/com/ing/wbaa/rokku/sts/api/UserApiTest.scala
+++ b/src/test/scala/com/ing/wbaa/rokku/sts/api/UserApiTest.scala
@@ -21,7 +21,7 @@ class UserApiTest extends WordSpec
 
   trait testUserApi extends UserApi {
     override def isCredentialActive(awsAccessKey: AwsAccessKey, awsSessionToken: Option[AwsSessionToken]): Future[Option[STSUserInfo]] =
-      Future.successful(Some(STSUserInfo(UserName("username"), Set(UserGroup("group1"), UserGroup("group2")), AwsAccessKey("a"), AwsSecretKey("s"))))
+      Future.successful(Some(STSUserInfo(UserName("username"), Set(UserGroup("group1"), UserGroup("group2")), AwsAccessKey("a"), AwsSecretKey("s"), None)))
   }
 
   val testSystem: ActorSystem = ActorSystem.create("test-system")
@@ -49,7 +49,7 @@ class UserApiTest extends WordSpec
           .addHeader(RawHeader("Authorization", bearerToken)) ~> testRoute ~> check {
             assert(status == StatusCodes.OK)
             val response = responseAs[String]
-            assert(response == """{"accessKey":"a","secretKey":"s","userGroups":["group1","group2"],"userName":"username"}""")
+            assert(response == """{"accessKey":"a","secretKey":"s","userGroups":["group1","group2"],"userName":"username","userRole":""}""")
           }
       }
 

--- a/src/test/scala/com/ing/wbaa/rokku/sts/data/aws/AwsRoleArnTest.scala
+++ b/src/test/scala/com/ing/wbaa/rokku/sts/data/aws/AwsRoleArnTest.scala
@@ -1,0 +1,42 @@
+package com.ing.wbaa.rokku.sts.data.aws
+
+import com.ing.wbaa.rokku.sts.data._
+import org.scalatest.WordSpec
+
+class AwsRoleArnTest extends WordSpec {
+
+  "AwsRoleArn" should {
+
+    "get groups a user can assume" that {
+      "could parse arn and existed in groups" in {
+        val testRoleName = "admin"
+
+        val result = AwsRoleArn(s"arn:aws:iam::123456789012:role/$testRoleName")
+          .getRoleUserCanAssume(
+            AuthenticationUserInfo(UserName(""), Set.empty, AuthenticationTokenId(""), Set(UserAssumeRole(testRoleName)))
+          )
+        assert(result.contains(UserAssumeRole(testRoleName)))
+      }
+
+      "could not parse arn, invalid ARN" in {
+        val testRoleName = "admin"
+
+        val result = AwsRoleArn(s"arn:aws:iam:invalid:123456789012:role/$testRoleName")
+          .getRoleUserCanAssume(
+            AuthenticationUserInfo(UserName(""), Set.empty, AuthenticationTokenId(""), Set(UserAssumeRole(testRoleName)))
+          )
+        assert(result.isEmpty)
+      }
+
+      "doesn't exist in groups of user" in {
+        val testRoleName = "admin"
+
+        val result = AwsRoleArn(s"arn:aws:iam::123456789012:role/$testRoleName")
+          .getRoleUserCanAssume(
+            AuthenticationUserInfo(UserName(""), Set.empty, AuthenticationTokenId(""), Set.empty)
+          )
+        assert(result.isEmpty)
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html

To obtain credential for a role user has to belong to the role in a keycloak (the information is in JWT returned by keycloak and provided to roku-sts)