### PR TITLE
Introduce k8s auth instead of vault token auth

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -64,8 +64,12 @@ db-dispatcher {
 vault {
     url = ${?STS_VAULT_URL}
     path = ${?STS_VAULT_SECRET_PATH}
-    token = ${?STS_VAULT_TOKEN}
     retries = ${?STS_VAULT_RETRIES}
     read-timeout= ${?STS_VAULT_READ_TIMEOUT}
     open-timeout = ${?STS_VAULT_OPEN_TIMEOUT}
+        service-account {
+            token-location = ${?STS_SA_TOKEN_LOCATION}
+            auth-path = ${?STS_VAULT_AUTH_PATH}
+            role= ${?STS_VAULT_ROLE}
+        }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -50,8 +50,12 @@ db-dispatcher {
 vault {
     url = "http://127.0.0.1:8200"
     path = "secret"
-    token = "admin"
     retries = 3
     read-timeout= 10
     open-timeout = 5
+    service-account {
+        token-location = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+        auth-path = "k8s"
+        role="demo"
+    }
 }

--- a/src/main/scala/com/ing/wbaa/rokku/sts/config/VaultSettings.scala
+++ b/src/main/scala/com/ing/wbaa/rokku/sts/config/VaultSettings.scala
@@ -3,14 +3,18 @@ package com.ing.wbaa.rokku.sts.config
 import akka.actor.{ ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider }
 import com.typesafe.config.Config
 
+import scala.io.Source
+
 class VaultSettings(config: Config) extends Extension {
 
   val vaultUrl: String = config.getString("vault.url")
   val vaultPath: String = config.getString("vault.path")
-  val vaultToken: String = config.getString("vault.token")
   val readTimeout: Int = config.getInt("vault.read-timeout")
   val openTimeout: Int = config.getInt("vault.open-timeout")
   val retries: Int = config.getInt("vault.retries")
+  val jwt: String = Source.fromFile(config.getString("vault.service-account.token-location")).getLines().next()
+  val auth: String = config.getString("vault.service-account.auth-path")
+  val role: String = config.getString("vault.service-account.role")
 
 }
 

--- a/src/test/scala/com/ing/wbaa/rokku/sts/api/AdminApiTest.scala
+++ b/src/test/scala/com/ing/wbaa/rokku/sts/api/AdminApiTest.scala
@@ -108,7 +108,7 @@ class AdminApiTest extends AnyWordSpec
           }
       }
       "return Rejected if user FormData is invalid" in {
-        Post("/admin/npa", FormData("npaAccount" -> "testNPA",  "safeName" -> "vault", "awsAccessKey" -> "SomeAccessKey")) ~> validOAuth2TokenHeader ~> testRoute ~> check {
+        Post("/admin/npa", FormData("npaAccount" -> "testNPA", "safeName" -> "vault", "awsAccessKey" -> "SomeAccessKey")) ~> validOAuth2TokenHeader ~> testRoute ~> check {
           assert(rejections.contains(MissingFormFieldRejection("awsSecretKey")))
         }
       }


### PR DESCRIPTION
This PR introduces a breaking change for auth configuration. Token auth has been superseded with kubernetes authentication.
$token has been removed in favor of service-account block in the configuration file. The token is still being used underneath but instead of the administrator needing to provide it when the application starts, it is being retrieved from vault using jwt mounted to the pod by kubernetes. See [https://www.vaultproject.io/docs/auth/kubernetes](url) for more details on the authentication.