### PR TITLE
Feature/new keycloak conf

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,6 @@ dockerCommands ++= Seq(
   Cmd("ENV", "PROXY_HOST", "0.0.0.0"),
   Cmd("USER", "root"),
   Cmd("RUN", "apt-get update && apt-get upgrade -y"),
-  Cmd("USER", "1001"),
 )
 
 

--- a/src/it/scala/com/ing/wbaa/rokku/sts/helper/OAuth2TokenRequest.scala
+++ b/src/it/scala/com/ing/wbaa/rokku/sts/helper/OAuth2TokenRequest.scala
@@ -29,7 +29,7 @@ trait OAuth2TokenRequest {
   private def getTokenResponse(formData: Map[String, String]): Future[HttpResponse] = {
     val contentType = RawHeader("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8")
     Http().singleRequest(HttpRequest(
-      uri = Uri(s"${keycloakSettings.url}/auth/realms/${keycloakSettings.realm}/protocol/openid-connect/token"),
+      uri = Uri(s"${keycloakSettings.url}${keycloakSettings.httpRelativePath}/realms/${keycloakSettings.realm}/protocol/openid-connect/token"),
       method = HttpMethods.POST,
       headers = List(contentType),
       entity = akka.http.scaladsl.model.FormData(formData).toEntity))

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -27,7 +27,7 @@ rokku {
             clientSecret = ${?KEYCLOAK_CLIENT_SECRET}
             adminUsername = ${?KEYCLOAK_ADMIN_USERNAME}
             adminPassword = ${?KEYCLOAK_ADMIN_PASSWORD}
-
+            httpRelativePath = ${?KEYCLOAK_HTTP_RELATIVE_PATH}
             verifyToken {
                 checkRealmUrl = ${?KEYCLOAK_CHECK_REALM_URL}
                 issuerForList = ${?KEYCLOAK_CHECK_ISSUER_FOR_LIST}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -14,6 +14,7 @@ rokku {
             clientSecret = "q4dHVTDyViys4T0njCSSoS5Xto4GjA12"
             adminUsername = "rokkuadmin"
             adminPassword = "password"
+            httpRelativePath = "/auth"
             verifyToken {
                 checkRealmUrl = true
                 issuerForList = "sts-rokku"
@@ -33,7 +34,7 @@ redis {
     host = "localhost"
     port = 6379
     username = "default"
-    password = "password" 
+    password = "password"
 }
 
 db-dispatcher {

--- a/src/main/scala/com/ing/wbaa/rokku/sts/config/KeycloakSettings.scala
+++ b/src/main/scala/com/ing/wbaa/rokku/sts/config/KeycloakSettings.scala
@@ -16,6 +16,7 @@ class KeycloakSettings(config: Config) extends Extension {
   val clientSecret: String = rokkuStsKeycloakConfig.getString("clientSecret")
   val adminUsername: String = rokkuStsKeycloakConfig.getString("adminUsername")
   val adminPassword: String = rokkuStsKeycloakConfig.getString("adminPassword")
+  val httpRelativePath: String = rokkuStsKeycloakConfig.getString("httpRelativePath") //can be removed when keyclock docker image for dev will be upgraded to version 18 or above (see https://www.keycloak.org/server/all-config#_httptls http-relative-path)
 }
 
 object KeycloakSettings extends ExtensionId[KeycloakSettings] with ExtensionIdProvider {

--- a/src/main/scala/com/ing/wbaa/rokku/sts/keycloak/KeycloakTokenVerifier.scala
+++ b/src/main/scala/com/ing/wbaa/rokku/sts/keycloak/KeycloakTokenVerifier.scala
@@ -52,7 +52,7 @@ trait KeycloakTokenVerifier extends LazyLogging {
   private[this] lazy val keycloakDeployment = {
     val config = new AdapterConfig()
     config.setRealm(keycloakSettings.realm)
-    config.setAuthServerUrl(s"${keycloakSettings.url}/auth")
+    config.setAuthServerUrl(s"${keycloakSettings.url}${keycloakSettings.httpRelativePath}/")
     config.setSslRequired("external")
     config.setResource(keycloakSettings.resource)
     config.setPublicClient(true)


### PR DESCRIPTION
- allow set config for keycloak http relative path introduced in keycloack from version 18 (https://www.keycloak.org/server/all-config#_httptls - see: http-relative-path) 
- remove user from docker image and allow it run as root