### PR TITLE
Validate accessKey/sessionToken content + refactor JWT verification

### DIFF
--- a/src/main/scala/com/ing/wbaa/rokku/sts/api/UserApi.scala
+++ b/src/main/scala/com/ing/wbaa/rokku/sts/api/UserApi.scala
@@ -6,7 +6,7 @@ import akka.http.scaladsl.server.Route
 import com.ing.wbaa.rokku.sts.data.aws.{ AwsAccessKey, AwsSessionToken }
 import com.ing.wbaa.rokku.sts.data.{ RequestId, STSUserInfo, UserAssumeRole, UserGroup }
 import com.ing.wbaa.rokku.sts.handler.LoggerHandlerWithId
-import com.ing.wbaa.rokku.sts.util.{ JwtToken, JwtTokenException }
+import com.ing.wbaa.rokku.sts.util.JwtToken
 import spray.json.RootJsonFormat
 
 import scala.concurrent.Future
@@ -26,6 +26,10 @@ trait UserApi extends JwtToken {
   implicit val userGroup: RootJsonFormat[UserGroup] = jsonFormat(UserGroup, "value")
   implicit val userInfoJsonFormat: RootJsonFormat[UserInfoToReturn] = jsonFormat5(UserInfoToReturn)
 
+  def containsOnlyAlphanumeric(value: String): Boolean = {
+    value.matches("""^[\w\d]*$""")
+  }
+
   def isCredentialActive: Route = logRequestResult("debug") {
     path("isCredentialActive") {
       get {
@@ -36,34 +40,28 @@ trait UserApi extends JwtToken {
               case None    => RequestId("")
             }
 
-            try {
-              val isBearerTokenValid = verifyInternalToken(bearerToken)
-              if (isBearerTokenValid) {
-                parameters("accessKey", "sessionToken".?) { (accessKey, sessionToken) =>
-                  onSuccess(isCredentialActive(AwsAccessKey(accessKey), sessionToken.map(AwsSessionToken))) {
+            verifyInternalToken(bearerToken) {
+              parameters("accessKey", "sessionToken".?) { (accessKey, sessionToken) =>
+                validate(containsOnlyAlphanumeric(accessKey), s"bad accessKey format=$accessKey") {
+                  validate(containsOnlyAlphanumeric(sessionToken getOrElse ""), s"bad sessionToken format=${sessionToken.get}") {
 
-                    case Some(userInfo) =>
-                      logger.info("isCredentialActive ok for accessKey={}, sessionToken={}", accessKey, sessionToken)
-                      complete((StatusCodes.OK, UserInfoToReturn(
-                        userInfo.userName.value,
-                        userInfo.userGroup.map(_.value),
-                        userInfo.awsAccessKey.value,
-                        userInfo.awsSecretKey.value,
-                        userInfo.userRole.getOrElse(UserAssumeRole("")).value)))
+                    onSuccess(isCredentialActive(AwsAccessKey(accessKey), sessionToken.map(AwsSessionToken))) {
+                      case Some(userInfo) =>
+                        logger.info("isCredentialActive ok for accessKey={}, sessionToken={}", accessKey, sessionToken)
+                        complete((StatusCodes.OK, UserInfoToReturn(
+                          userInfo.userName.value,
+                          userInfo.userGroup.map(_.value),
+                          userInfo.awsAccessKey.value,
+                          userInfo.awsSecretKey.value,
+                          userInfo.userRole.getOrElse(UserAssumeRole("")).value)))
 
-                    case None =>
-                      logger.warn("isCredentialActive forbidden for accessKey={}, sessionToken={}", accessKey, sessionToken)
-                      complete(StatusCodes.Forbidden)
+                      case None =>
+                        logger.warn("isCredentialActive forbidden for accessKey={}, sessionToken={}", accessKey, sessionToken)
+                        complete(StatusCodes.Forbidden)
+                    }
                   }
                 }
-              } else {
-                logger.warn("isCredentialActive not verified for token={}", bearerToken)
-                complete(StatusCodes.Forbidden)
               }
-            } catch {
-              case ex: JwtTokenException =>
-                logger.warn("isCredentialActive malformed token={}, $s", bearerToken, ex.getMessage)
-                complete(StatusCodes.BadRequest)
             }
           }
         }

--- a/src/main/scala/com/ing/wbaa/rokku/sts/handler/StsExceptionHandlers.scala
+++ b/src/main/scala/com/ing/wbaa/rokku/sts/handler/StsExceptionHandlers.scala
@@ -6,14 +6,11 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.ExceptionHandler
 import com.ing.wbaa.rokku.sts.data.aws.{ AwsErrorCodes, AwsRoleArnException }
 import com.ing.wbaa.rokku.sts.keycloak.KeycloakException
-import com.ing.wbaa.rokku.sts.util.JwtTokenException
 
 object StsExceptionHandlers {
 
   val exceptionHandler: ExceptionHandler =
     ExceptionHandler {
-      case ex: JwtTokenException =>
-        complete(StatusCodes.Forbidden -> AwsErrorCodes.response(StatusCodes.Forbidden, message = Some(ex.getMessage)))
       case ex: KeycloakException =>
         complete(StatusCodes.Forbidden -> AwsErrorCodes.response(StatusCodes.Forbidden, message = Some(ex.getMessage)))
       case ex: AwsRoleArnException =>

--- a/src/test/scala/com/ing/wbaa/rokku/sts/api/AdminApiTest.scala
+++ b/src/test/scala/com/ing/wbaa/rokku/sts/api/AdminApiTest.scala
@@ -103,8 +103,8 @@ class AdminApiTest extends AnyWordSpec
       }
       "return Rejected if service token is not correct" in {
         Post("/admin/service/npa", FormData("npaAccount" -> "testNPA1", "safeName" -> "vault", "awsAccessKey" -> "SomeAccessKey", "awsSecretKey" -> "SomeSecretKey"))
-          .addHeader(RawHeader("Authorization", bearerToken("rokku1"))) ~> testRoute ~> check {
-            assert(status == StatusCodes.InternalServerError)
+          .addHeader(RawHeader("Authorization", bearerToken("rokku1"))) ~> Route.seal(testRoute) ~> check {
+            assert(status == StatusCodes.BadRequest)
           }
       }
       "return Rejected if user FormData is invalid" in {

--- a/src/test/scala/com/ing/wbaa/rokku/sts/api/UserApiTest.scala
+++ b/src/test/scala/com/ing/wbaa/rokku/sts/api/UserApiTest.scala
@@ -3,7 +3,7 @@ package com.ing.wbaa.rokku.sts.api
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.RawHeader
-import akka.http.scaladsl.server.{ MissingHeaderRejection, MalformedHeaderRejection, AuthorizationFailedRejection, MissingQueryParamRejection, ValidationRejection, Route }
+import akka.http.scaladsl.server.{ MissingHeaderRejection, MalformedHeaderRejection, AuthorizationFailedRejection, MissingQueryParamRejection, Route }
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
@@ -102,22 +102,14 @@ class UserApiTest extends AnyWordSpec
       "check credential and return status bad request because the accessKey contains non-alphanumeric characters" in {
         Get(s"/isCredentialActive?accessKey=access-key!with@special*characters&sessionToken=session")
           .addHeader(RawHeader("Authorization", generateBearerToken())) ~> testRoute ~> check {
-            assert(rejection == ValidationRejection("bad accessKey format=access-key!with@special*characters"))
-          }
-        Get(s"/isCredentialActive?accessKey=access-key!with@special*characters&sessionToken=session")
-          .addHeader(RawHeader("Authorization", generateBearerToken())) ~> Route.seal(testRoute) ~> check {
-            assert(status == StatusCodes.BadRequest)
+            assert(status == StatusCodes.Forbidden)
           }
       }
 
       "check credential and return status bad request because the sessionToken contains non-alphanumeric characters" in {
         Get(s"/isCredentialActive?accessKey=access&sessionToken=session!with@special*characters")
           .addHeader(RawHeader("Authorization", generateBearerToken())) ~> testRoute ~> check {
-            assert(rejection == ValidationRejection("bad sessionToken format=session!with@special*characters"))
-          }
-        Get(s"/isCredentialActive?accessKey=access&sessionToken=session!with@special*characters")
-          .addHeader(RawHeader("Authorization", generateBearerToken())) ~> Route.seal(testRoute) ~> check {
-            assert(status == StatusCodes.BadRequest)
+            assert(status == StatusCodes.Forbidden)
           }
       }
 


### PR DESCRIPTION
Added a step to reject request if provided accessKey/sessionToken contains any special characters, as they would have to be escaped for database query.
Refactored JWT verification to not rely on exceptions during normal flow and to make it more FP oriented.