### PR TITLE
Get empty string for logs if request doesn't contain sessionToken

### DIFF
--- a/src/main/scala/com/ing/wbaa/rokku/sts/api/UserApi.scala
+++ b/src/main/scala/com/ing/wbaa/rokku/sts/api/UserApi.scala
@@ -48,7 +48,7 @@ trait UserApi extends JwtToken {
             verifyInternalToken(bearerToken) {
               parameters("accessKey", "sessionToken".?) { (accessKey, sessionToken) =>
                 containsOnlyAlphanumeric(accessKey, s"bad accessKey format=$accessKey") {
-                  containsOnlyAlphanumeric(sessionToken getOrElse "", s"bad sessionToken format=${sessionToken.get}") {
+                  containsOnlyAlphanumeric(sessionToken getOrElse "", s"bad sessionToken format=${sessionToken getOrElse ""}") {
 
                     onSuccess(isCredentialActive(AwsAccessKey(accessKey), sessionToken.map(AwsSessionToken))) {
                       case Some(userInfo) =>

--- a/src/test/scala/com/ing/wbaa/rokku/sts/api/UserApiTest.scala
+++ b/src/test/scala/com/ing/wbaa/rokku/sts/api/UserApiTest.scala
@@ -113,6 +113,13 @@ class UserApiTest extends AnyWordSpec
           }
       }
 
+      "check credential and return ok because the accessKey exist and sessionToken is missing (NPA)" in {
+        Get(s"/isCredentialActive?accessKey=access")
+          .addHeader(RawHeader("Authorization", generateBearerToken())) ~> testRoute ~> check {
+            assert(status == StatusCodes.OK)
+          }
+      }
+
     }
   }
 }


### PR DESCRIPTION
Fixes exception that is thrown when request does not contain `sessionToken` and adds test for this case